### PR TITLE
自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -3,7 +3,7 @@ $(document).on('turbolinks:load', function(){
   function buildHTML(message) {
     var content = message.content ? `${ message.content }` : "";
     var img = message.image ? `<img src= ${ message.image }>` : "";
-    var html = `<div class="message" data-id="${message.id}">
+    var html = `<div class="message" data-message-id="${message.id}">
                   <div class="message__detail">
                     <p class="message__detail__current-user-name">
                       ${message.user_name}
@@ -37,15 +37,8 @@ $(document).on('turbolinks:load', function(){
       var html = buildHTML(data);
       $('.messages').append(html);
       $('form')[0].reset();
-    }
-          ,function scrollBottom(){
-      var target = $('.message').last();
-      var position = target.offset().top + $('.messages').scrollTop();
-      $('.messages').animate({
-        scrollTop: position
-      }, 300, 'swing');
-    }
-    )
+      $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');
+    })
     .fail(function(data){
       alert('エラーが発生したためメッセージは送信できませんでした。');
     })
@@ -53,4 +46,29 @@ $(document).on('turbolinks:load', function(){
       $(".form__submit").removeAttr("disabled");
     })
   })
-});
+
+   var reloadMessages = function () {
+    if (window.location.href.match(/\/groups\/\d+\/messages/)){
+      var last_message_id = $('.message:last').data("message-id"); 
+
+      $.ajax({ 
+        url: "api/messages", 
+        type: 'get', 
+        dataType: 'json', 
+        data: {id: last_message_id} 
+      })
+      .done(function (messages) { 
+        var insertHTML = '';
+        messages.forEach(function (message) {
+          insertHTML = buildHTML(message); 
+          $('.messages').append(insertHTML);
+        })
+        $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');
+      })
+      .fail(function () {
+        alert('自動更新に失敗しました');
+      });
+    }
+  };
+  setInterval(reloadMessages, 5000);
+  });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,6 @@
+class Api::MessagesController < ApplicationController
+  def index
+    @group = Group.find(params[:group_id])
+    @messages = @group.messages.includes(:user).where('id > ?', params[:id])
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,13 +11,6 @@ class UsersController < ApplicationController
     end
   end
 
-  # def flash
-  #   flash[:success] = アカウントが登録されました。
-  #   flash[:rogin_m] = ログインしました。
-  #   flash[:rogout_m] = ログインまたは登録が必要です。
-  # end
-
-
   private
 
   def user_params

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content       message.content
+    json.image       message.image.url
+    json.date        message.created_at.strftime("%Y/%m/%d %H:%M")
+    json.user_name   message.user.name
+    json.id          message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,11 +1,11 @@
-.message
-  .upper-message
-    .upper-message__user-name
+
+.message{"data-message-id": "#{message.id}"}
+  .message__detail
+    .message__detail__current-user-name
       = message.user.name
-    .upper-message__date
+    .message__detail__date
       = message.created_at.strftime("%Y/%m/%d %H:%M")
-  .lower-message
-    - if message.content.present?
-      %p.lower-message__content
-        = message.content
-    = image_tag message.image.url, class: 'lower-message__image' if message.image.present?
+  - if message.content.present?
+    .message_body
+      = message.content
+  = image_tag message.image.url, class: 'lower-message__image' if message.image.present?

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,3 +1,5 @@
+json.(@message, :content, :image)
+json.created_at @message.created_at
 json.id      @message.id
 json.content @message.content 
 json.date    @message.created_at.strftime("%Y/%m/%d %H:%M")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,11 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root 'groups#index'
-  resources :users, only: [:edit, :update]
+  resources :users, only: [:index,:edit, :update]
   resources :groups,only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
<h2>what</h2>
自動でチャット画面が更新されるようにしました。

<h2>what</h2>
現在まで、自分が投稿した場合は、非同期通信で画面に投稿したメッセージが表示されますが、別のユーザーが別の画面から投稿したメッセージはリロードしなければ表示されないので。

↓キャプチャ
https://gyazo.com/e49e019d9efb26accaa3c792ffd520b6